### PR TITLE
add arxiv_id and location-specific doi

### DIFF
--- a/models/location.py
+++ b/models/location.py
@@ -52,6 +52,7 @@ class Location(db.Model):
     endpoint_id = db.Column(db.Text, db.ForeignKey("mid.journal.repository_id"))
     evidence = db.Column(db.Text)
     updated = db.Column(db.Text)
+    doi = db.Column(db.Text)  # it is possible for any location to have its own doi
 
     @property
     def is_oa(self):
@@ -114,6 +115,12 @@ class Location(db.Model):
                 return True  # else is probably a component or stub record
         return False
 
+    @property
+    def doi_url(self):
+        if not self.doi:
+            return None
+        return "https://doi.org/{}".format(self.doi.lower())
+
     def has_any_url(self):
         return bool(self.url_for_pdf or self.url_for_landing_page or self.source_url)
 
@@ -152,6 +159,7 @@ class Location(db.Model):
             "version": self.version,
             "license": self.display_license,
             # "repository_institution": self.repository_institution,
+            "doi": self.doi_url,
         }
 
         return response
@@ -164,6 +172,7 @@ class Location(db.Model):
             'is_oa': self.is_oa,
             'version': self.version,
             'license': self.display_license,
+            'doi': self.doi_url,
         }
 
     def __repr__(self):


### PR DESCRIPTION
Okay, my head is spinning a bit from trying to wrap my head around this, but I think I got it. The goal is to add `arxiv_id` to works that have it, and to add `doi` to locations (and dehydrated locations in works).

I have added a "doi" column to mid.location, and an "arxiv_id" column to mid.work.

When `add_everything()` is called, it should populate `arxiv_id` if it's available in any record (privileging a record direct from arXiv). This is in `add_ids()`. In `add_locations()`, it will construct an arXiv DOI and override the doi with that when creating the arXiv location.

In `dict_locations()`---which, as I understand it, is where we get dehydrated locations for json---the location is now populated with a doi url if available.

If this is all correct, it can be merged in, and new works from recordthresher will start getting arxiv_id and location-specific dois. I can then make changes in openalex-elastic-api to expose it in the API. However, all existing works will need to  be updated with arxiv_id manually (if they have arxiv IDs).