### PR TITLE
use original_affiliation if lookup in ins.recordthresher_record fails

### DIFF
--- a/models/work.py
+++ b/models/work.py
@@ -248,6 +248,7 @@ class Work(db.Model):
                 key=lambda a: a.affiliation_sequence_number
             )
 
+            original_affiliations = []
             if update_original_affiliations:
                 original_affiliations = [
                     aff.get('name')
@@ -255,7 +256,7 @@ class Work(db.Model):
                     if aff.get('name')
                 ]
                 is_corresponding_author = record_author_dict_list[author_idx].get('is_corresponding', False)
-            else:
+            if not original_affiliations:
                 original_affiliations = [a.original_affiliation for a in author_affiliations if a.original_affiliation]
                 is_corresponding_author = author_affiliations[0].is_corresponding_author
 


### PR DESCRIPTION
From what I could tell, information in the original_affiliation field in mid.affiliation was not propagating, because it was preferencing what was in ins.recordthresher_record. I'm not sure if this is the best fix, but what this does is use the raw string found in mid.affiliation if no affiliation strings are found in ins.recordthresher_record.

I'm not sure where the strings come from in either mid.affiliation, or ins.recordthresher_record. Hence the more conservative approach: I don't know which one should be preferenced. But it seemed reasonable to me to use the original_affiliation in mid.affiliation if we have it, at least in the case where it looks in recordthresher_record but comes up empty-handed.